### PR TITLE
NGワードリストをオブジェクトにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Normalizes input string in the following ways:
 ## Usage
 
 ```
-const badWordList = [
-	"苺",
-	"ジュース",
-	"watermelon",
-];
+const badWordList = {
+	苺: [],
+	ジュース: [],
+	watermelon: [],
+};
 
 const badWordDetector = new BadWordDetector(badWordList);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 import { deburr } from "lodash";
-export class BadWordDetector {
-	private wordList: string[];
 
-	constructor(wordList: string[]) {
+// key is the word itself, value is an array of words containing key which should be allowed (whitelist)
+interface WordList {
+	[wordToDetect: string]: string[];
+}
+
+export class BadWordDetector {
+	private wordList: WordList;
+
+	constructor(wordList: WordList) {
 		this.wordList = wordList;
 	}
 
@@ -33,7 +39,7 @@ export class BadWordDetector {
 	}
 
 	private containsExactMatch(word: string): boolean {
-		return this.wordList.includes(word);
+		return this.wordList.hasOwnProperty(word);
 	}
 
 	private containsPartialMatch(word: string): boolean {
@@ -49,7 +55,8 @@ export class BadWordDetector {
 
 				const toCheck = word.substring(i, maxIndex + 1);
 
-				if (this.wordList.includes(toCheck)) {
+				if (this.wordList.hasOwnProperty(toCheck)) {
+					// todo: whitelist
 					return true;
 				}
 				maxIndex++;

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -1,19 +1,19 @@
 import { BadWordDetector } from "../";
 
 // BadWordDetector converts hiragana to katakana when checking, so base list should not contain hiragana
-const blacklistedWordList = [
-	"strawberry",
-	"スイカ",
-	"西瓜",
-	"メロン",
-	"passionfruit",
-	"桃",
-	"苺",
-	"キウィ",
-	"ジュース",
-	"アサイー",
-	"ピザ",
-];
+const wordList = {
+	strawberry: [],
+	スイカ: [],
+	西瓜: [],
+	メロン: [],
+	passionfruit: [],
+	桃: [],
+	苺: [],
+	キウィ: [],
+	ジュース: [],
+	アサイー: [],
+	ピザ: [],
+};
 
 // BadWordDetector should detect all these
 const testBlacklistedInput = [
@@ -65,7 +65,7 @@ const testOkInput = [
 ];
 
 describe("BadWordDetector", () => {
-	const detector = new BadWordDetector(blacklistedWordList);
+	const detector = new BadWordDetector(wordList);
 
 	it("Returns true when string contains a blacklisted word", () => {
 		for (const badWord of testBlacklistedInput) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,8 @@
 	},
 	"include": [
 		"src/**/*.ts"
+	],
+	"exclude": [
+		"src/tests/*.ts"
 	]
 }


### PR DESCRIPTION
試しにbadWordListをこういうフォーマットにする：

```
{
  [ngWord1]: string[]; //←ngWord1が入っているけどOKにしたいワード
  [ngWord2]: string[];
}
```
- メリット：ホワイトリストの処理がはやくなる、普通の処理もはやくなる
- デメリット：同じ単語を複数のNGワードのホワイトリストに入れないと行けないかも、管理が面倒かも、ホワイトリストが空っぽだとなんとなくみてて気持ち悪い

嫌だったらこのPRをクローズします！