### PR TITLE
whitelistのバグ修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bad-word-detector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Detect if input string contains blacklisted words",
   "main": "build/index.js",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,9 @@ export class BadWordDetector {
 
 						return this.containsMatchAfterRemovingWhitelistedWord(word, okWord, occurringIndex);
 					}
+
+					// the bad word was not whitelisted
+					return true;
 				}
 				maxIndex++;
 			}

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -39,7 +39,8 @@ const testBlacklistedInput = [
 	"ぴざ",
 	"ぴざAぽ",
 	"サクランボ",
-	"オッケーサクランボサクランボ"
+	"オッケーサクランボサクランボ",
+	"superbadサクランボああ"
 ];
 
 // BadWordDetector should allow these


### PR DESCRIPTION
「渡されたNGワードにはwhitelistデータがあって、しかしそのNGワード自体がwhitelistに入っていなかった場合は毎回`false`を返してしまう」バグの修正です。